### PR TITLE
Cleaner base64 encoding

### DIFF
--- a/compress.ps1
+++ b/compress.ps1
@@ -1,2 +1,2 @@
-$base64 = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes('C:\Users\monpolo\Desktop\google_RAT-master\stager.ps1'))
+$base64 = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes(''))
 $base64

--- a/compress.ps1
+++ b/compress.ps1
@@ -1,0 +1,2 @@
+$base64 = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes('C:\Users\monpolo\Desktop\google_RAT-master\stager.ps1'))
+$base64


### PR DESCRIPTION
Doesn't eliminate whitespace as original did in your readme, but original was also failing to encode as easily.